### PR TITLE
Fix broken "quickstart" link

### DIFF
--- a/docs/cpu-architecture.mdx
+++ b/docs/cpu-architecture.mdx
@@ -41,7 +41,7 @@ Though there are numerous ways to deploy containers using techniques such as emu
 Currently GitHub Actions does not support native arm64 runners. They are [working to add](https://github.com/actions/runner-images/issues/5631) this feature.
 :::
 
-Our <DocLink id="quickstart" /> guide has your first deploy happening from your local machine. Since we default to `arm64` this should work fine if you are on a Mac with Apple Silicon. But what if you are on a Windows or Linux system with an `x86_64` architecture? Your function will not work since your application's system dependences (like mysq2) will be compiled for the wrong architecture. Depending on your needs, you may have to switch back to `x86_64` as described below.
+Our <DocLink id="quick-start" /> guide has your first deploy happening from your local machine. Since we default to `arm64` this should work fine if you are on a Mac with Apple Silicon. But what if you are on a Windows or Linux system with an `x86_64` architecture? Your function will not work since your application's system dependences (like mysq2) will be compiled for the wrong architecture. Depending on your needs, you may have to switch back to `x86_64` as described below.
 
 For more information on deployments, see our <DocLink id="anatomy" /> guide.
 


### PR DESCRIPTION
### Description

Super minor typo fix on the CPU Architecture page for the quick-start link.


### Changes
quickstart => quick-start to make the link work.

##### Updated Dependencies
 - None
<!--
Please include any notes that might be helpful for a reviewer to check the dependency changes you might have introduced.
  - gem version update
  - new gem introduced
  - data model update
-->

### Ticket

n/a

### Screenshots
![CleanShot 2023-03-05 at 23 26 23@2x](https://user-images.githubusercontent.com/444766/223019393-ad082cd9-25c8-420f-9036-fc959a2db4b1.png)

### Notes

_Recommended reading: [Code Review guide](https://github.com/customink/guides/blob/master/operations/code-review/README.md)_

<!--
Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
-->

### Optional Tasks


- [x] Update the API or architecture docs (e.g. docs/api.md)

##### Library-Specific

- [ ] Increment the changelog (CHANGELOG.md)
- [ ] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

##### Performance
- Are there any new queries in your change set that might require new indexes?
- Do any new queries require time-boxing to avoid table-scans when the data grows?

### What GIF Best Describes This Pull Request?

![](https://media.tenor.com/GC5stv3gqDcAAAAC/stickergiant-this-is-not-a-big-deal.gif)
