### PR TITLE
Update quick-start.mdx

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -84,7 +84,7 @@ Now we can run the deploy script which uses the AWS SAM CLI.
 Deploy scripts are best run via automated CI/CD system such as GitHub Actions. Please see our full <DocLink id="anatomy" anchor="deployment--cicd" /> deployment section
 :::
 
-## Yay! Your're on Rails!
+## Yay! You're on Rails!
 
 At the end of the deploy process above, you will see SAM print the outputs for the CloudFormation template being deployed. This includes your Lambda Function URL, a free web server proxy to your Lambda container running Rails.
 


### PR DESCRIPTION
Fix heading typo "Yay! Your're on Rails" -> "Yay! You're on Rails!"